### PR TITLE
Update composer.json for compatibility with robo 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "robo-tasks",
     "require": {
         "typhonius/acquia-php-sdk-v2": "^1.1.2",
-        "consolidation/robo": "^1.0",
+        "consolidation/robo": ">=1.0",
         "php": ">=7.1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
In order to upgrade a Drupal 9 project for compatibility with PHP8, it requires to upgrade Drush to lates version (v11) and for that it requires "consolidation/robo:3.0.10" which conflicts with the requirements of this library.
I updated the composer.json file to allow it.